### PR TITLE
fix: frontend compose port mismatch and docker build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${FRONTEND_HOST_PORT:-15173}:5173"
+      - "${FRONTEND_HOST_PORT:-15173}:8080"
     depends_on:
       - backend
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.tsbuildinfo
+npm-debug.log*
+.DS_Store


### PR DESCRIPTION
## Summary
- map frontend host port to container port 8080 (nginx runtime)
- add frontend/.dockerignore to exclude node_modules/dist/tsbuildinfo from build context

## Why
- avoid frontend unreachable issue caused by 15173:5173 mapping while nginx listens on 8080
- prevent docker build failures from invalid files under node_modules in local environments

## Verification
- docker compose config
- docker compose build frontend