### PR TITLE
fix: frontend nginxでAutheliaヘッダをbackendへ転送

### DIFF
--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -12,6 +12,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-User $http_x_forwarded_user;
+        proxy_set_header X-Forwarded-Email $http_x_forwarded_email;
+        proxy_set_header X-Forwarded-Preferred-Username $http_x_forwarded_preferred_username;
     }
 
     location / {


### PR DESCRIPTION
## 概要
Authelia保護下で /api/auth/me などのAPI呼び出し時に、フロント側nginxが認証ヘッダをbackendへ渡していなかったため、AUTH_MODE=proxy-header でセッション連携できない問題を修正します。

## 変更内容
- rontend/nginx/default.conf の location /api/ に以下を追加
  - X-Forwarded-User
  - X-Forwarded-Email
  - X-Forwarded-Preferred-Username

## 影響範囲
- frontend nginx のAPIリバースプロキシ設定のみ
- backend/frontendアプリコード本体のロジック変更なし

## 確認観点
- Autheliaログイン済みで、frontend経由APIアクセス時にbackendがユーザー識別できること
