### PR TITLE
企業追加フォームのUIUX改善

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -251,8 +251,9 @@ body {
 
 .row {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 input,
@@ -271,6 +272,7 @@ select,
 textarea {
   background: #fff;
   color: var(--text-main);
+  transition: border-color 160ms ease, box-shadow 160ms ease;
 }
 
 input {
@@ -278,21 +280,41 @@ input {
   min-width: 180px;
 }
 
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  border-color: #78bec9;
+  box-shadow: 0 0 0 3px rgba(120, 190, 201, 0.28);
+}
+
 button {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
   cursor: pointer;
-  transition: filter 160ms ease;
+  font-weight: 600;
+  transition: filter 160ms ease, transform 120ms ease, box-shadow 120ms ease;
 }
 
 button:hover {
   filter: brightness(1.04);
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
 }
 
 button:disabled {
   opacity: 0.56;
   cursor: not-allowed;
+  transform: none;
+}
+
+button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(120, 190, 201, 0.28);
 }
 
 .button-secondary {
@@ -301,17 +323,80 @@ button:disabled {
   border-color: #9fd8df;
 }
 
+.button-danger {
+  background: #ce4330;
+  color: #fff;
+  border-color: #bb3725;
+}
+
+.button-danger:hover {
+  filter: brightness(1.03);
+  box-shadow: 0 6px 16px rgba(187, 55, 37, 0.28);
+}
+
+.button-danger:disabled {
+  box-shadow: none;
+}
+
+.button-add-step {
+  min-width: 148px;
+}
+
 .step-builder {
   border: 1px dashed #aac7e2;
   border-radius: 12px;
-  padding: 10px;
-  background: #f8fcff;
+  padding: 12px;
+  background: #f7fcff;
+  display: grid;
+  gap: 10px;
+}
+
+.step-builder-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
 }
 
 .step-builder p {
-  margin: 0 0 8px;
+  margin: 0;
   color: var(--text-sub);
   font-size: 13px;
+}
+
+.step-count {
+  border-radius: 999px;
+  border: 1px solid #c7d8ec;
+  background: #f1f7ff;
+  color: #476685;
+  font-size: 12px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.step-builder-list {
+  display: grid;
+  gap: 8px;
+}
+
+.step-builder-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) minmax(220px, 1fr) minmax(120px, 140px) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.step-builder-row input,
+.step-builder-row select {
+  width: 100%;
+  min-width: 0;
+}
+
+.step-builder-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 8px;
+  border-top: 1px dashed #cfe1f1;
 }
 
 .actions {
@@ -498,9 +583,11 @@ button:disabled {
 }
 
 .inline-step-add {
-  margin-top: 10px;
-  border-top: 1px dashed #d5deea;
-  padding-top: 10px;
+  margin-top: 12px;
+  border: 1px dashed #cfe0ef;
+  border-radius: 12px;
+  background: #fafdff;
+  padding: 10px;
   display: grid;
   gap: 8px;
 }
@@ -939,6 +1026,22 @@ button:disabled {
 
   .flow-node {
     min-width: 108px;
+  }
+
+  .step-builder-header {
+    align-items: flex-start;
+  }
+
+  .step-builder-row {
+    grid-template-columns: 1fr;
+  }
+
+  .step-builder-actions {
+    justify-content: stretch;
+  }
+
+  .button-add-step {
+    width: 100%;
   }
 
   .agenda-item {

--- a/frontend/src/components/CompaniesView.tsx
+++ b/frontend/src/components/CompaniesView.tsx
@@ -128,41 +128,48 @@ export function CompaniesView({
           </div>
 
           <div className="step-builder">
-            <p>初期選考フロー</p>
-            {newSteps.map((step, index) => (
-              <div className="row" key={`new-step-${index}`}>
-                <select value={step.kind} onChange={(e) => onUpdateNewStep(index, { kind: e.target.value })}>
-                  {stepKindOptions.map((kind) => (
-                    <option key={kind} value={kind}>
-                      {kind}
-                    </option>
-                  ))}
-                </select>
-                <input
-                  value={step.title}
-                  onChange={(e) => onUpdateNewStep(index, { title: e.target.value })}
-                  placeholder="表示名（任意）"
-                />
-                <select value={step.status} onChange={(e) => onUpdateNewStep(index, { status: e.target.value })}>
-                  {stepStatusOptions.map((status) => (
-                    <option key={status} value={status}>
-                      {status}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  className="button-secondary"
-                  onClick={() => onRemoveNewStep(index)}
-                  disabled={newSteps.length <= 1}
-                >
-                  削除
-                </button>
-              </div>
-            ))}
-            <button type="button" className="button-secondary" onClick={onAddNewStep}>
-              ステップ追加
-            </button>
+            <div className="step-builder-header">
+              <p>初期選考フロー</p>
+              <span className="step-count">{newSteps.length} step</span>
+            </div>
+            <div className="step-builder-list">
+              {newSteps.map((step, index) => (
+                <div className="step-builder-row" key={`new-step-${index}`}>
+                  <select value={step.kind} onChange={(e) => onUpdateNewStep(index, { kind: e.target.value })}>
+                    {stepKindOptions.map((kind) => (
+                      <option key={kind} value={kind}>
+                        {kind}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    value={step.title}
+                    onChange={(e) => onUpdateNewStep(index, { title: e.target.value })}
+                    placeholder="表示名（任意）"
+                  />
+                  <select value={step.status} onChange={(e) => onUpdateNewStep(index, { status: e.target.value })}>
+                    {stepStatusOptions.map((status) => (
+                      <option key={status} value={status}>
+                        {status}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    className="button-danger"
+                    onClick={() => onRemoveNewStep(index)}
+                    disabled={newSteps.length <= 1}
+                  >
+                    削除
+                  </button>
+                </div>
+              ))}
+            </div>
+            <div className="step-builder-actions">
+              <button type="button" className="button-secondary button-add-step" onClick={onAddNewStep}>
+                + ステップ追加
+              </button>
+            </div>
           </div>
 
           <div className="actions">


### PR DESCRIPTION
概要
企業追加フォームを中心に、誤操作しにくいレイアウトへ改善しました。

主な変更
- 初期選考フロー入力行をgrid化し、入力項目と削除ボタンの密着を解消
- ステップ追加ボタンを入力行から分離して右寄せ配置
- 削除ボタンを危険操作として赤系スタイルに変更
- 入力欄とボタンのフォーカス視認性を改善
- インラインステップ追加領域を枠付きカード化
- モバイルでステップ入力行が縦積みになるよう調整

変更ファイル
- frontend/src/components/CompaniesView.tsx
- frontend/src/App.css

動作確認
- この環境ではnodeとnpmが未導入のためnpm run buildは未実施
