### PR TITLE
Tailwind CSS導入とダークモード対応によるUI刷新

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,8 +17,24 @@
         "@types/react": "^18.3.9",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.41",
+        "tailwindcss": "^3.4.17",
         "typescript": "^5.6.2",
         "vite": "^5.4.8"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -744,6 +760,44 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1253,6 +1307,72 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -1274,6 +1394,32 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -1308,6 +1454,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1381,6 +1537,44 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -1391,12 +1585,35 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1455,6 +1672,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -1540,6 +1771,73 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1555,6 +1853,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1563,6 +1871,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -1645,6 +1979,35 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-decimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
@@ -1653,6 +2016,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-hexadecimal": {
@@ -1665,6 +2051,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -1675,6 +2071,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-tokens": {
@@ -1708,6 +2114,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -2019,6 +2445,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/micromark": {
@@ -2584,11 +3020,37 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2616,6 +3078,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -2641,6 +3143,13 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2648,10 +3157,43 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
       "dev": true,
       "funding": [
         {
@@ -2669,13 +3211,140 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -2686,6 +3355,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -2747,6 +3437,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -2815,6 +3528,38 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -2858,6 +3603,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/scheduler": {
@@ -2931,6 +3700,193 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -2950,6 +3906,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -3083,6 +4046,13 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -3171,12 +4141,57 @@
         }
       }
     },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,9 @@
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.6.2",
     "vite": "^5.4.8"
   }

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}
+

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,1035 +1,802 @@
-:root {
-  --bg-top: #eef6ff;
-  --bg-bottom: #fff4de;
-  --panel: rgba(255, 255, 255, 0.94);
-  --line: #d8e4f2;
-  --text-main: #1d2733;
-  --text-sub: #5b6b81;
-  --accent: #0c6f79;
-  --accent-soft: #e4f8fb;
-  --warn: #ca4428;
-  --shadow: 0 14px 30px rgba(23, 40, 61, 0.1);
-  --topbar: #0f3550;
-  --topbar-text: #eaf4ff;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  color: var(--text-main);
-  font-family: "Zen Kaku Gothic New", "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
-  background: radial-gradient(circle at 0% 0%, #d7f3ff 0%, transparent 45%),
-    radial-gradient(circle at 100% 15%, #ffe8c6 0%, transparent 40%),
-    linear-gradient(180deg, var(--bg-top), var(--bg-bottom));
-}
-
-.app-shell {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 20px 18px 44px;
-  display: grid;
-  gap: 16px;
-  position: relative;
-}
-
-.topbar {
-  position: sticky;
-  top: 10px;
-  z-index: 50;
-  border-radius: 16px;
-  border: 1px solid #194e70;
-  background: linear-gradient(120deg, var(--topbar), #165777 64%, #17706c);
-  color: var(--topbar-text);
-  box-shadow: var(--shadow);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 10px 12px;
-}
-
-.topbar-title h1 {
-  margin: 0;
-  font-size: clamp(1rem, 2.2vw, 1.36rem);
-}
-
-.topbar-title .eyebrow {
-  margin: 0 0 4px;
-  font-size: 11px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  opacity: 0.88;
-}
-
-.icon-button {
-  width: 40px;
-  height: 40px;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.icon-button span {
-  width: 18px;
-  height: 2px;
-  border-radius: 99px;
-  background: #f3fbff;
-}
-
-.topbar-meta {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.view-chip,
-.user-chip {
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  padding: 7px 11px;
-  font-size: 12px;
-  color: #ecf8ff;
-  background: rgba(255, 255, 255, 0.16);
-  white-space: nowrap;
-}
-
-.user-chip {
-  max-width: min(260px, 30vw);
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.drawer {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 70;
-  width: min(280px, 84vw);
-  height: 100vh;
-  background: #fff;
-  border-right: 1px solid var(--line);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14);
-  padding: 22px 16px;
-  transform: translateX(-102%);
-  transition: transform 200ms ease;
-  display: grid;
-  align-content: start;
-  gap: 10px;
-}
-
-.drawer.open {
-  transform: translateX(0);
-}
-
-.drawer-title {
-  margin: 0 0 8px;
-  color: var(--text-sub);
-  font-size: 13px;
-  letter-spacing: 0.08em;
-}
-
-.drawer-group {
-  display: grid;
-  gap: 8px;
-}
-
-.drawer-divider {
-  margin: 8px 0;
-  border-top: 1px solid #e3ebf4;
-}
-
-.drawer-subtitle {
-  margin: 0;
-  color: var(--text-sub);
-  font-size: 12px;
-  letter-spacing: 0.06em;
-}
-
-.drawer-item {
-  text-align: left;
-  border-radius: 10px;
-  border: 1px solid var(--line);
-  background: #f6fbff;
-  color: var(--text-main);
-}
-
-.drawer-item.active {
-  border-color: #96ced5;
-  background: #e7f8fb;
-  color: #125c65;
-}
-
-.drawer-link {
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  border: 1px solid #d8e4f2;
-  background: #f7f9fc;
-  color: #21425b;
-  min-height: 40px;
-}
-
-.account-card {
-  border: 1px solid #dce7f4;
-  border-radius: 10px;
-  background: #f8fbff;
-  padding: 10px;
-  display: grid;
-  gap: 4px;
-}
-
-.account-card strong {
-  font-size: 14px;
-}
-
-.account-card small {
-  color: #5d6f86;
-}
-
-.drawer-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 65;
-  background: rgba(15, 28, 47, 0.35);
-  border: 0;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 180ms ease;
-}
-
-.drawer-backdrop.show {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.hero {
-  padding: 18px 20px;
-  border-radius: 16px;
-  color: #10415f;
-  background: linear-gradient(125deg, #d7efff, #e3fbf3 58%, #fff2d6);
-  border: 1px solid #c8e0f5;
-  box-shadow: var(--shadow);
-  animation: rise 420ms ease-out both;
-}
-
-.hero-sub {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  box-shadow: var(--shadow);
-  padding: 16px;
-  animation: rise 420ms ease-out both;
-}
-
-.panel h2 {
-  margin: 0 0 10px;
-  font-size: 1.02rem;
-}
-
-.stack {
-  display: grid;
-  gap: 10px;
-}
-
-.row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-input,
-select,
-textarea,
-button {
-  border-radius: 10px;
-  border: 1px solid var(--line);
-  padding: 10px 12px;
-  font-size: 14px;
-  font-family: inherit;
-}
-
-input,
-select,
-textarea {
-  background: #fff;
-  color: var(--text-main);
-  transition: border-color 160ms ease, box-shadow 160ms ease;
-}
-
-input {
-  flex: 1;
-  min-width: 180px;
-}
-
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: none;
-  border-color: #78bec9;
-  box-shadow: 0 0 0 3px rgba(120, 190, 201, 0.28);
-}
-
-button {
-  background: var(--accent);
-  color: #fff;
-  border-color: var(--accent);
-  cursor: pointer;
-  font-weight: 600;
-  transition: filter 160ms ease, transform 120ms ease, box-shadow 120ms ease;
-}
-
-button:hover {
-  filter: brightness(1.04);
-  transform: translateY(-1px);
-}
-
-button:active {
-  transform: translateY(0);
-}
-
-button:disabled {
-  opacity: 0.56;
-  cursor: not-allowed;
-  transform: none;
-}
-
-button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(120, 190, 201, 0.28);
-}
-
-.button-secondary {
-  background: var(--accent-soft);
-  color: #165965;
-  border-color: #9fd8df;
-}
-
-.button-danger {
-  background: #ce4330;
-  color: #fff;
-  border-color: #bb3725;
-}
-
-.button-danger:hover {
-  filter: brightness(1.03);
-  box-shadow: 0 6px 16px rgba(187, 55, 37, 0.28);
-}
-
-.button-danger:disabled {
-  box-shadow: none;
-}
-
-.button-add-step {
-  min-width: 148px;
-}
-
-.step-builder {
-  border: 1px dashed #aac7e2;
-  border-radius: 12px;
-  padding: 12px;
-  background: #f7fcff;
-  display: grid;
-  gap: 10px;
-}
-
-.step-builder-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-}
-
-.step-builder p {
-  margin: 0;
-  color: var(--text-sub);
-  font-size: 13px;
-}
-
-.step-count {
-  border-radius: 999px;
-  border: 1px solid #c7d8ec;
-  background: #f1f7ff;
-  color: #476685;
-  font-size: 12px;
-  padding: 2px 8px;
-  white-space: nowrap;
-}
-
-.step-builder-list {
-  display: grid;
-  gap: 8px;
-}
-
-.step-builder-row {
-  display: grid;
-  grid-template-columns: minmax(120px, 160px) minmax(220px, 1fr) minmax(120px, 140px) auto;
-  gap: 8px;
-  align-items: center;
-}
-
-.step-builder-row input,
-.step-builder-row select {
-  width: 100%;
-  min-width: 0;
-}
-
-.step-builder-actions {
-  display: flex;
-  justify-content: flex-end;
-  padding-top: 8px;
-  border-top: 1px dashed #cfe1f1;
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.error {
-  margin: 0;
-  color: var(--warn);
-  font-weight: 600;
-}
-
-.muted {
-  margin: 0;
-  color: var(--text-sub);
-}
-
-.company-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 12px;
-}
-
-.company-card {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  box-shadow: var(--shadow);
-  padding: 12px;
-  animation: rise 420ms ease-out both;
-}
-
-.company-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  align-items: flex-start;
-}
-
-.company-heading {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.company-head h3 {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.company-toggle {
-  white-space: nowrap;
-  padding: 8px 12px;
-}
-
-.badge {
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-size: 12px;
-  background: #ecf9fa;
-  color: #0b6570;
-  border: 1px solid #b8e4e9;
-  white-space: nowrap;
-}
-
-.flow-summary {
-  margin-top: 10px;
-  display: grid;
-  gap: 8px;
-}
-
-.flow-current {
-  margin: 0;
-  color: #2a4a67;
-  font-weight: 700;
-  font-size: 13px;
-}
-
-.flow-strip {
-  border: 1px solid #d9e6f2;
-  border-radius: 10px;
-  background: #f9fbff;
-  padding: 8px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  overflow-x: auto;
-}
-
-.flow-empty {
-  color: #6a7a8f;
-  font-size: 13px;
-}
-
-.flow-arrow {
-  color: #8da2b8;
-  font-size: 12px;
-  flex: 0 0 auto;
-}
-
-.flow-node {
-  min-width: 120px;
-  border-radius: 10px;
-  border: 1px solid #d4dfeb;
-  background: #fff;
-  padding: 6px 8px;
-  display: grid;
-  gap: 2px;
-  flex: 0 0 auto;
-}
-
-.flow-node strong {
-  font-size: 12px;
-  line-height: 1.2;
-}
-
-.flow-node small {
-  color: #5e7088;
-  font-size: 11px;
-}
-
-.flow-node.pending {
-  border-color: #cddbeb;
-  background: #f7fbff;
-}
-
-.flow-node.done {
-  border-color: #95dbb4;
-  background: #e8faef;
-}
-
-.flow-node.stopped {
-  border-color: #e8b4b4;
-  background: #fff0f0;
-}
-
-.flow-node.current {
-  box-shadow: 0 0 0 2px #ffd270 inset;
-}
-
-.company-detail {
-  margin-top: 10px;
-  border-top: 1px dashed #d5deea;
-  padding-top: 10px;
-}
-
-.detail-caption {
-  font-size: 13px;
-}
-
-.step-list {
-  margin-top: 10px;
-  display: grid;
-  gap: 8px;
-}
-
-.step-item {
-  border: 1px solid #d8e5f2;
-  border-radius: 10px;
-  background: #fff;
-  padding: 8px;
-}
-
-.step-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
-}
-
-.kind {
-  font-size: 12px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: #f2f6ff;
-  border: 1px solid #d3dff5;
-  color: #2a4f96;
-}
-
-.step-row {
-  align-items: center;
-}
-
-.inline-step-add {
-  margin-top: 12px;
-  border: 1px dashed #cfe0ef;
-  border-radius: 12px;
-  background: #fafdff;
-  padding: 10px;
-  display: grid;
-  gap: 8px;
-}
-
-.doc-editor {
-  margin-top: 10px;
-  border-top: 1px dashed #d5deea;
-  padding-top: 10px;
-  display: grid;
-  gap: 8px;
-}
-
-.doc-editor h4 {
-  margin: 0;
-  font-size: 14px;
-  color: #284866;
-}
-
-.doc-label {
-  font-size: 13px;
-  color: #4f6782;
-  font-weight: 700;
-}
-
-.doc-textarea {
-  width: 100%;
-  min-height: 160px;
-  resize: vertical;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  line-height: 1.5;
-}
-
-.doc-link {
-  color: #0b5d66;
-  font-size: 13px;
-  text-decoration: underline;
-}
-
-.doc-mode-toggle {
-  display: flex;
-  gap: 8px;
-}
-
-.active-toggle {
-  background: #d6f4f8;
-  border-color: #73c6d0;
-  color: #0e5660;
-  font-weight: 700;
-}
-
-.doc-preview {
-  border: 1px solid #d8e5f2;
-  border-radius: 10px;
-  background: #fbfdff;
-  padding: 12px;
-  min-height: 120px;
-}
-
-.doc-preview :first-child {
-  margin-top: 0;
-}
-
-.doc-preview :last-child {
-  margin-bottom: 0;
-}
-
-.doc-preview h1,
-.doc-preview h2,
-.doc-preview h3 {
-  color: #244867;
-}
-
-.doc-preview code {
-  background: #eef5ff;
-  border-radius: 6px;
-  padding: 2px 6px;
-}
-
-.site-footer {
-  border-top: 1px solid #d8e4f2;
-  margin-top: 8px;
-  padding-top: 16px;
-  padding-bottom: 8px;
-  color: #607389;
-  font-size: 12px;
-  display: grid;
-  gap: 4px;
-}
-
-.site-footer p {
-  margin: 0;
-}
-
-.site-footer a {
-  color: #0d5c66;
-}
-
-.auth-panel h2 {
-  margin-bottom: 8px;
-}
-
-.auth-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 10px;
-}
-
-.auth-grid form {
-  border: 1px solid #d8e4f2;
-  border-radius: 12px;
-  padding: 10px;
-  background: #fafdff;
-}
-
-.auth-grid h3 {
-  margin: 0;
-  font-size: 14px;
-  color: #2b4f6e;
-}
-
-.auth-current {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.auth-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 40px;
-  border-radius: 10px;
-  border: 1px solid #9fd8df;
-  background: #e4f8fb;
-  color: #145f67;
-  text-decoration: none;
-  padding: 8px 12px;
-  font-weight: 600;
-}
-
-.auth-note {
-  border: 1px solid #d8e4f2;
-  border-radius: 12px;
-  padding: 10px;
-  background: #fafdff;
-}
-
-.timeline-toolbar {
-  display: grid;
-  gap: 10px;
-}
-
-.timeline-meta {
-  font-size: 13px;
-}
-
-.month-badge {
-  border: 1px solid #9fd7de;
-  border-radius: 999px;
-  padding: 9px 14px;
-  background: #eefafb;
-  color: #125d66;
-  font-weight: 600;
-}
-
-.timeline-panel {
-  overflow: hidden;
-}
-
-.timeline-scroll {
-  overflow: auto;
-  max-width: 100%;
-  border: 1px solid #d2e0ee;
-  border-radius: 12px;
-  background: #fff;
-}
-
-.timeline-grid {
-  display: grid;
-  min-width: max-content;
-}
-
-.timeline-header {
-  position: sticky;
-  top: 0;
-  z-index: 5;
-  text-align: center;
-  border-bottom: 1px solid #d7e4f1;
-  border-right: 1px solid #ebf1f7;
-  background: #f5f9ff;
-  padding: 8px 4px;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.timeline-header small {
-  display: block;
-  color: #667589;
-  font-weight: 500;
-  font-size: 11px;
-}
-
-.timeline-header.weekend {
-  background: #fdf4f4;
-}
-
-.sticky-col {
-  position: sticky;
-  left: 0;
-  z-index: 6;
-}
-
-.timeline-company {
-  display: grid;
-  gap: 4px;
-  align-content: center;
-  border-right: 1px solid #dfe8f4;
-  border-bottom: 1px solid #ebf1f7;
-  background: #f9fbff;
-  padding: 8px;
-}
-
-.timeline-company.has-before {
-  box-shadow: inset 4px 0 0 #f4b037;
-}
-
-.timeline-company.has-after {
-  box-shadow: inset -4px 0 0 #f4b037;
-}
-
-.timeline-company.has-before.has-after {
-  box-shadow: inset 4px 0 0 #f4b037, inset -4px 0 0 #f4b037;
-}
-
-.timeline-company strong {
-  font-size: 13px;
-}
-
-.timeline-company small {
-  color: #6a7a8d;
-  font-size: 11px;
-}
-
-.timeline-edge-note {
-  color: #9a6200;
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.timeline-cell {
-  min-height: 74px;
-  border-right: 1px solid #f0f3f7;
-  border-bottom: 1px solid #ecf2f8;
-  padding: 4px;
-  display: grid;
-  gap: 4px;
-  align-content: start;
-}
-
-.timeline-cell.overflow-left,
-.timeline-cell.overflow-right {
-  position: relative;
-}
-
-.timeline-cell.overflow-left::before {
-  content: "◀";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 14px;
-  display: grid;
-  place-items: center;
-  color: #8f5600;
-  font-size: 10px;
-  background: linear-gradient(90deg, #ffd986 0%, rgba(255, 233, 179, 0.65) 55%, rgba(255, 255, 255, 0) 100%);
-}
-
-.timeline-cell.overflow-right::after {
-  content: "▶";
-  position: absolute;
-  inset: 0 0 0 auto;
-  width: 14px;
-  display: grid;
-  place-items: center;
-  color: #8f5600;
-  font-size: 10px;
-  background: linear-gradient(270deg, #ffd986 0%, rgba(255, 233, 179, 0.65) 55%, rgba(255, 255, 255, 0) 100%);
-}
-
-.timeline-event {
-  border: 1px solid #95d2dc;
-  background: #e6f8fb;
-  border-radius: 8px;
-  padding: 4px 6px;
-  display: grid;
-  gap: 2px;
-}
-
-.timeline-event span {
-  font-size: 11px;
-  font-weight: 700;
-  color: #114f58;
-}
-
-.timeline-event small {
-  font-size: 10px;
-  color: #28717a;
-}
-
-.agenda-panel {
-  overflow: hidden;
-}
-
-.agenda-days {
-  display: grid;
-  gap: 10px;
-}
-
-.agenda-day {
-  border: 1px solid #d5e3f1;
-  border-radius: 12px;
-  background: #fff;
-  overflow: hidden;
-}
-
-.agenda-day-head {
-  padding: 10px 12px;
-  border-bottom: 1px solid #e7eef7;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: #f7fbff;
-}
-
-.agenda-day-head strong {
-  font-size: 14px;
-}
-
-.agenda-day-head span {
-  color: #5f7289;
-  font-size: 12px;
-}
-
-.agenda-list {
-  display: grid;
-}
-
-.agenda-item {
-  padding: 10px 12px;
-  border-top: 1px solid #edf2f8;
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.agenda-item:first-child {
-  border-top: 0;
-}
-
-.agenda-main {
-  display: grid;
-  gap: 2px;
-}
-
-.agenda-company {
-  font-size: 12px;
-  color: #5b6f88;
-}
-
-.agenda-step {
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.agenda-side {
-  display: grid;
-  gap: 4px;
-  text-align: right;
-}
-
-.agenda-company-status,
-.agenda-step-status {
-  border: 1px solid #c8dae8;
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 11px;
-  background: #f6fbff;
-  color: #2b5f7c;
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    --bg-top: #f2f6fb;
+    --bg-bottom: #e7edf5;
+    --panel: rgba(255, 255, 255, 0.9);
+    --line: #d5dde8;
+    --line-strong: #aebaca;
+    --text-main: #0f172a;
+    --text-sub: #475569;
+    --accent: #0f766e;
+    --accent-soft: #e6f5f3;
+    --accent-line: #9bcfc8;
+    --warn: #b42318;
+    --shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    --topbar: #0f172a;
+    --topbar-text: #e2e8f0;
+  }
+
+  :root.dark {
+    color-scheme: dark;
+    --bg-top: #0b1220;
+    --bg-bottom: #111b2f;
+    --panel: rgba(17, 25, 40, 0.82);
+    --line: #263348;
+    --line-strong: #334155;
+    --text-main: #e2e8f0;
+    --text-sub: #94a3b8;
+    --accent: #14b8a6;
+    --accent-soft: rgba(20, 184, 166, 0.14);
+    --accent-line: #1f766c;
+    --warn: #ef4444;
+    --shadow: 0 16px 40px rgba(2, 6, 23, 0.45);
+    --topbar: #020617;
+    --topbar-text: #e2e8f0;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html,
+  body,
+  #root {
+    @apply min-h-full;
+  }
+
+  body {
+    margin: 0;
+    color: var(--text-main);
+    font-family: "Zen Kaku Gothic New", "Noto Sans JP", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+    background: radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent) 12%, transparent), transparent 42%),
+      linear-gradient(180deg, var(--bg-top), var(--bg-bottom));
+  }
+
+  input,
+  select,
+  textarea {
+    @apply rounded-md border bg-white px-3 py-2 text-sm outline-none transition;
+    border-color: var(--line);
+    color: var(--text-main);
+    min-height: 40px;
+  }
+
+  .dark input,
+  .dark select,
+  .dark textarea {
+    @apply bg-slate-900/70;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 26%, transparent);
+  }
+
+  button {
+    @apply inline-flex min-h-10 items-center justify-center rounded-md border px-3 py-2 text-sm font-medium tracking-wide transition;
+    border-color: var(--accent);
+    background: var(--accent);
+    color: #f8fafc;
+    cursor: pointer;
+  }
+
+  button:hover {
+    filter: brightness(0.95);
+  }
+
+  button:active {
+    transform: translateY(1px);
+  }
+
+  button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  a {
+    color: inherit;
+  }
+}
+
+@layer components {
+  .app-shell {
+    @apply relative mx-auto grid max-w-[1360px] gap-4 px-4 pb-10 pt-5 sm:px-6;
+  }
+
+  .topbar {
+    @apply sticky top-3 z-50 flex items-center justify-between gap-3 rounded-lg border px-3 py-3 backdrop-blur;
+    border-color: color-mix(in srgb, var(--topbar-text) 20%, transparent);
+    background: color-mix(in srgb, var(--topbar) 88%, transparent);
+    color: var(--topbar-text);
+    box-shadow: var(--shadow);
+  }
+
+  .topbar-title h1 {
+    @apply m-0 text-lg sm:text-xl;
+  }
+
+  .topbar-title .eyebrow {
+    @apply mb-1 mt-0 text-[10px] uppercase tracking-[0.16em];
+    opacity: 0.76;
+  }
+
+  .icon-button {
+    @apply h-10 w-10 shrink-0 rounded-md border p-0;
+    border-color: color-mix(in srgb, var(--topbar-text) 18%, transparent);
+    background: color-mix(in srgb, var(--topbar-text) 10%, transparent);
+  }
+
+  .icon-button span {
+    @apply block h-[2px] w-[18px] rounded-full;
+    background: color-mix(in srgb, var(--topbar-text) 92%, transparent);
+  }
+
+  .topbar-meta {
+    @apply flex items-center gap-2;
+  }
+
+  .view-chip,
+  .user-chip {
+    @apply rounded-md border px-3 py-2 text-xs;
+    border-color: color-mix(in srgb, var(--topbar-text) 20%, transparent);
+    background: color-mix(in srgb, var(--topbar-text) 8%, transparent);
+    color: color-mix(in srgb, var(--topbar-text) 95%, transparent);
+  }
+
+  .user-chip {
+    @apply max-w-[240px] truncate;
+  }
+
+  .theme-toggle {
+    @apply gap-2 rounded-md border px-3 py-2 text-xs;
+    border-color: color-mix(in srgb, var(--topbar-text) 20%, transparent);
+    background: color-mix(in srgb, var(--topbar-text) 8%, transparent);
+    color: color-mix(in srgb, var(--topbar-text) 95%, transparent);
+  }
+
+  .theme-dot {
+    @apply h-2.5 w-2.5 rounded-full;
+    background: color-mix(in srgb, var(--topbar-text) 90%, transparent);
+  }
+
+  .dark .theme-dot {
+    background: #facc15;
+  }
+
+  .drawer {
+    @apply fixed left-0 top-0 grid h-dvh w-[min(300px,86vw)] -translate-x-[102%] content-start gap-2 border-r p-5 transition-transform;
+    z-index: 70;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 100%, #000 0%);
+    box-shadow: var(--shadow);
+  }
+
+  .drawer.open {
+    @apply translate-x-0;
+  }
+
+  .drawer-title {
+    @apply mb-2 mt-0 text-xs uppercase tracking-[0.14em];
+    color: var(--text-sub);
+  }
+
+  .drawer-group {
+    @apply grid gap-2;
+  }
+
+  .drawer-divider {
+    @apply my-2 border-t;
+    border-color: var(--line);
+  }
+
+  .drawer-subtitle {
+    @apply mb-0 mt-1 text-xs uppercase tracking-[0.12em];
+    color: var(--text-sub);
+  }
+
+  .drawer-item {
+    @apply w-full justify-start rounded-md border bg-transparent text-left;
+    border-color: var(--line);
+    color: var(--text-main);
+  }
+
+  .drawer-item.active {
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  .drawer-link {
+    @apply inline-flex min-h-10 items-center justify-center rounded-md border px-3 py-2 text-sm font-medium no-underline transition;
+    border-color: var(--line);
+    color: var(--text-main);
+    background: color-mix(in srgb, var(--panel) 88%, transparent);
+  }
+
+  .account-card {
+    @apply grid gap-1 rounded-md border p-3;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 90%, transparent);
+  }
+
+  .account-card strong {
+    @apply text-sm;
+  }
+
+  .account-card small {
+    @apply text-xs;
+    color: var(--text-sub);
+  }
+
+  .drawer-backdrop {
+    @apply pointer-events-none fixed inset-0 border-0 bg-slate-950/40 opacity-0 transition-opacity;
+    z-index: 60;
+  }
+
+  .drawer-backdrop.show {
+    @apply pointer-events-auto opacity-100;
+  }
+
+  .hero {
+    @apply rounded-lg border px-5 py-4;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 96%, transparent);
+    box-shadow: var(--shadow);
+    animation: rise 220ms ease-out both;
+  }
+
+  .hero-sub {
+    @apply m-0 text-sm font-medium;
+    color: var(--text-sub);
+  }
+
+  .panel {
+    @apply rounded-lg border p-4;
+    border-color: var(--line);
+    background: var(--panel);
+    box-shadow: var(--shadow);
+    animation: rise 220ms ease-out both;
+  }
+
+  .panel h2 {
+    @apply mb-3 mt-0 text-base font-semibold;
+  }
+
+  .stack {
+    @apply grid gap-2.5;
+  }
+
+  .row {
+    @apply flex flex-wrap items-center gap-2.5;
+  }
+
+  .row > input {
+    @apply min-w-[220px] flex-1;
+  }
+
+  .button-secondary {
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  .button-danger {
+    border-color: color-mix(in srgb, var(--warn) 75%, black);
+    background: var(--warn);
+    color: #fff;
+  }
+
+  .button-add-step {
+    @apply min-w-[150px];
+  }
+
+  .step-builder {
+    @apply grid gap-2.5 rounded-md border p-3;
+    border-color: color-mix(in srgb, var(--line-strong) 72%, transparent);
+    background: color-mix(in srgb, var(--panel) 95%, transparent);
+  }
+
+  .step-builder-header {
+    @apply flex items-center justify-between gap-2;
+  }
+
+  .step-builder p {
+    @apply m-0 text-xs uppercase tracking-[0.12em];
+    color: var(--text-sub);
+  }
+
+  .step-count {
+    @apply rounded-full border px-2 py-0.5 text-[11px];
+    border-color: var(--line);
+    color: var(--text-sub);
+  }
+
+  .step-builder-list {
+    @apply grid gap-2;
+  }
+
+  .step-builder-row {
+    @apply grid items-center gap-2;
+    grid-template-columns: minmax(120px, 150px) minmax(220px, 1fr) minmax(120px, 140px) auto;
+  }
+
+  .step-builder-row input,
+  .step-builder-row select {
+    @apply min-w-0 w-full;
+  }
+
+  .step-builder-actions {
+    @apply flex justify-end border-t pt-2;
+    border-color: var(--line);
+  }
+
+  .actions {
+    @apply flex justify-end;
+  }
+
+  .error {
+    @apply m-0 text-sm font-semibold;
+    color: var(--warn);
+  }
+
+  .muted {
+    @apply m-0 text-sm;
+    color: var(--text-sub);
+  }
+
+  .company-grid {
+    @apply grid grid-cols-1 gap-3;
+  }
+
+  .company-card {
+    @apply rounded-lg border p-3;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 97%, transparent);
+    box-shadow: var(--shadow);
+  }
+
+  .company-head {
+    @apply flex items-start justify-between gap-2;
+  }
+
+  .company-heading {
+    @apply flex flex-wrap items-center gap-2;
+  }
+
+  .company-head h3 {
+    @apply m-0 text-base font-semibold;
+  }
+
+  .company-toggle {
+    @apply whitespace-nowrap;
+  }
+
+  .badge {
+    @apply rounded-full border px-2.5 py-0.5 text-xs;
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  .flow-summary {
+    @apply mt-3 grid gap-2;
+  }
+
+  .flow-current {
+    @apply m-0 text-xs font-semibold;
+    color: var(--text-sub);
+  }
+
+  .flow-strip {
+    @apply flex items-center gap-1.5 overflow-x-auto rounded-md border p-2;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 96%, transparent);
+  }
+
+  .flow-empty {
+    @apply text-xs;
+    color: var(--text-sub);
+  }
+
+  .flow-arrow {
+    @apply shrink-0 text-xs;
+    color: var(--text-sub);
+  }
+
+  .flow-node {
+    @apply grid shrink-0 gap-0.5 rounded-md border bg-white p-2 dark:bg-slate-900/80;
+    min-width: 126px;
+    border-color: var(--line);
+  }
+
+  .flow-node strong {
+    @apply text-xs font-semibold;
+  }
+
+  .flow-node small {
+    @apply text-[11px];
+    color: var(--text-sub);
+  }
+
+  .flow-node.pending {
+    background: color-mix(in srgb, var(--panel) 100%, transparent);
+  }
+
+  .flow-node.done {
+    border-color: color-mix(in srgb, #16a34a 35%, var(--line));
+    background: color-mix(in srgb, #16a34a 10%, transparent);
+  }
+
+  .flow-node.stopped {
+    border-color: color-mix(in srgb, var(--warn) 35%, var(--line));
+    background: color-mix(in srgb, var(--warn) 10%, transparent);
+  }
+
+  .flow-node.current {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 52%, transparent);
+  }
+
+  .company-detail {
+    @apply mt-3 border-t pt-3;
+    border-color: var(--line);
+  }
+
+  .detail-caption {
+    @apply text-xs;
+  }
+
+  .step-list {
+    @apply mt-3 grid gap-2;
+  }
+
+  .step-item {
+    @apply rounded-md border p-2;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 95%, transparent);
+  }
+
+  .step-label {
+    @apply mb-2 flex items-center gap-2;
+  }
+
+  .kind {
+    @apply rounded-full border px-2 py-0.5 text-[11px];
+    border-color: var(--line);
+    color: var(--text-sub);
+    background: color-mix(in srgb, var(--panel) 95%, transparent);
+  }
+
+  .step-row {
+    @apply items-center;
+  }
+
+  .inline-step-add {
+    @apply mt-3 grid gap-2 rounded-md border p-3;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 96%, transparent);
+  }
+
+  .doc-editor {
+    @apply mt-3 grid gap-2 border-t pt-3;
+    border-color: var(--line);
+  }
+
+  .doc-editor h4 {
+    @apply m-0 text-sm font-semibold;
+  }
+
+  .doc-label {
+    @apply text-xs font-semibold uppercase tracking-[0.08em];
+    color: var(--text-sub);
+  }
+
+  .doc-textarea {
+    @apply w-full resize-y;
+    min-height: 180px;
+    line-height: 1.6;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  }
+
+  .doc-link {
+    @apply text-xs underline;
+    color: var(--accent);
+  }
+
+  .doc-mode-toggle {
+    @apply flex gap-2;
+  }
+
+  .active-toggle {
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  .doc-preview {
+    @apply rounded-md border p-3;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 96%, transparent);
+    min-height: 124px;
+  }
+
+  .doc-preview :first-child {
+    margin-top: 0;
+  }
+
+  .doc-preview :last-child {
+    margin-bottom: 0;
+  }
+
+  .doc-preview code {
+    @apply rounded px-1.5 py-0.5 text-[13px];
+    background: color-mix(in srgb, var(--line) 55%, transparent);
+  }
+
+  .site-footer {
+    @apply mt-2 grid gap-1 border-t pt-4 text-xs;
+    border-color: var(--line);
+    color: var(--text-sub);
+  }
+
+  .site-footer p {
+    @apply m-0;
+  }
+
+  .site-footer a {
+    color: var(--accent);
+  }
+
+  .auth-panel h2 {
+    @apply mb-2;
+  }
+
+  .auth-grid {
+    @apply grid gap-2;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .auth-grid form,
+  .auth-note {
+    @apply rounded-md border p-3;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 97%, transparent);
+  }
+
+  .auth-grid h3 {
+    @apply m-0 text-sm font-semibold;
+  }
+
+  .auth-current {
+    @apply flex items-center justify-between gap-2;
+  }
+
+  .auth-link {
+    @apply inline-flex min-h-10 items-center justify-center rounded-md border px-3 py-2 text-sm font-semibold no-underline;
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  .timeline-toolbar {
+    @apply grid gap-2.5;
+  }
+
+  .timeline-meta {
+    @apply text-xs;
+  }
+
+  .month-badge {
+    @apply rounded-full border px-4 py-2 text-sm font-semibold;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 95%, transparent);
+  }
+
+  .timeline-panel,
+  .agenda-panel {
+    @apply overflow-hidden;
+  }
+
+  .timeline-scroll {
+    @apply max-w-full overflow-auto rounded-md border;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 97%, transparent);
+  }
+
+  .timeline-grid {
+    @apply grid;
+    min-width: max-content;
+  }
+
+  .timeline-header {
+    @apply sticky top-0 border-b border-r px-1 py-2 text-center text-xs font-semibold;
+    z-index: 5;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 98%, transparent);
+  }
+
+  .timeline-header small {
+    @apply text-[10px] font-normal;
+    color: var(--text-sub);
+  }
+
+  .timeline-header.weekend {
+    background: color-mix(in srgb, var(--warn) 10%, var(--panel));
+  }
+
+  .sticky-col {
+    @apply sticky left-0;
+    z-index: 6;
+  }
+
+  .timeline-company {
+    @apply grid content-center gap-1 border-b border-r p-2;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 99%, transparent);
+  }
+
+  .timeline-company.has-before {
+    box-shadow: inset 3px 0 0 #f59e0b;
+  }
+
+  .timeline-company.has-after {
+    box-shadow: inset -3px 0 0 #f59e0b;
+  }
+
+  .timeline-company.has-before.has-after {
+    box-shadow: inset 3px 0 0 #f59e0b, inset -3px 0 0 #f59e0b;
+  }
+
+  .timeline-company strong {
+    @apply text-xs font-semibold;
+  }
+
+  .timeline-company small {
+    @apply text-[11px];
+    color: var(--text-sub);
+  }
+
+  .timeline-edge-note {
+    @apply text-[10px] font-semibold;
+    color: #b45309;
+  }
+
+  .timeline-cell {
+    @apply grid content-start gap-1 border-b border-r p-1;
+    border-color: color-mix(in srgb, var(--line) 88%, transparent);
+    min-height: 72px;
+  }
+
+  .timeline-cell.overflow-left,
+  .timeline-cell.overflow-right {
+    @apply relative;
+  }
+
+  .timeline-cell.overflow-left::before {
+    content: "◀";
+    @apply absolute bottom-0 left-0 top-0 grid w-3.5 place-items-center text-[10px];
+    color: #92400e;
+    background: linear-gradient(90deg, rgba(245, 158, 11, 0.5) 0%, rgba(245, 158, 11, 0) 100%);
+  }
+
+  .timeline-cell.overflow-right::after {
+    content: "▶";
+    @apply absolute bottom-0 right-0 top-0 grid w-3.5 place-items-center text-[10px];
+    color: #92400e;
+    background: linear-gradient(270deg, rgba(245, 158, 11, 0.5) 0%, rgba(245, 158, 11, 0) 100%);
+  }
+
+  .timeline-event {
+    @apply grid gap-0.5 rounded border px-1.5 py-1;
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
+  }
+
+  .timeline-event span {
+    @apply text-[11px] font-semibold;
+    color: var(--accent);
+  }
+
+  .timeline-event small {
+    @apply text-[10px];
+    color: var(--text-sub);
+  }
+
+  .agenda-days {
+    @apply grid gap-2.5;
+  }
+
+  .agenda-day {
+    @apply overflow-hidden rounded-md border;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 97%, transparent);
+  }
+
+  .agenda-day-head {
+    @apply flex items-center justify-between border-b px-3 py-2;
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--panel) 99%, transparent);
+  }
+
+  .agenda-day-head strong {
+    @apply text-sm font-semibold;
+  }
+
+  .agenda-day-head span {
+    @apply text-xs;
+    color: var(--text-sub);
+  }
+
+  .agenda-list {
+    @apply grid;
+  }
+
+  .agenda-item {
+    @apply flex justify-between gap-3 border-t px-3 py-2;
+    border-color: color-mix(in srgb, var(--line) 82%, transparent);
+  }
+
+  .agenda-item:first-child {
+    border-top: 0;
+  }
+
+  .agenda-main {
+    @apply grid gap-0.5;
+  }
+
+  .agenda-company {
+    @apply text-xs;
+    color: var(--text-sub);
+  }
+
+  .agenda-step {
+    @apply text-sm font-semibold;
+  }
+
+  .agenda-side {
+    @apply grid gap-1 text-right;
+  }
+
+  .agenda-company-status,
+  .agenda-step-status {
+    @apply rounded-full border px-2 py-0.5 text-[11px];
+    border-color: var(--line);
+    color: var(--text-sub);
+    background: color-mix(in srgb, var(--panel) 95%, transparent);
+  }
 }
 
 @keyframes rise {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: translateY(4px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
-@media (max-width: 640px) {
-  .app-shell {
-    padding: 14px 10px 30px;
-  }
-
+@media (max-width: 768px) {
   .topbar-meta {
-    display: none;
-  }
-
-  .topbar {
-    top: 6px;
-    padding: 9px 10px;
-  }
-
-  .topbar-title h1 {
-    font-size: 1rem;
-  }
-
-  .topbar-title .eyebrow {
-    font-size: 10px;
-  }
-
-  .company-grid {
-    grid-template-columns: 1fr;
+    @apply hidden;
   }
 
   .company-head {
-    flex-direction: column;
-    align-items: stretch;
+    @apply flex-col items-stretch;
   }
 
   .company-toggle {
-    width: 100%;
-  }
-
-  .flow-node {
-    min-width: 108px;
-  }
-
-  .step-builder-header {
-    align-items: flex-start;
+    @apply w-full;
   }
 
   .step-builder-row {
@@ -1037,22 +804,18 @@ button:focus-visible {
   }
 
   .step-builder-actions {
-    justify-content: stretch;
+    @apply justify-stretch;
   }
 
   .button-add-step {
-    width: 100%;
+    @apply w-full;
   }
 
   .agenda-item {
-    flex-direction: column;
-    gap: 6px;
+    @apply flex-col gap-1.5;
   }
 
   .agenda-side {
-    text-align: left;
-    display: flex;
-    gap: 6px;
-    flex-wrap: wrap;
+    @apply flex flex-wrap gap-1.5 text-left;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,12 +8,14 @@ import { CompaniesView } from "./components/CompaniesView"
 import { TimelineView } from "./components/TimelineView"
 import { useCompanyManagement } from "./hooks/useCompanyManagement"
 import { useNavigation } from "./hooks/useNavigation"
+import { useTheme } from "./hooks/useTheme"
 import { useTimeline } from "./hooks/useTimeline"
 import { useViewer } from "./hooks/useViewer"
 
 export function App() {
   const viewer = useViewer({ apiBase })
   const navigation = useNavigation()
+  const theme = useTheme()
   const companies = useCompanyManagement({ apiBase })
   const timeline = useTimeline({ companies: companies.companies })
 
@@ -47,6 +49,8 @@ export function App() {
       viewerError={viewer.viewerError}
       logoutURL={logoutURL}
       onToggleMenu={navigation.toggleMenu}
+      theme={theme.theme}
+      onToggleTheme={theme.toggleTheme}
       onCloseMenu={navigation.closeMenu}
       onNavigate={navigation.navigateTo}
       onReload={onReload}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -6,10 +6,12 @@ type AppShellProps = {
   children: ReactNode
   isMenuOpen: boolean
   activeView: ViewKey
+  theme: "light" | "dark"
   viewer: AuthUser | null
   viewerError: string
   logoutURL: string
   onToggleMenu: () => void
+  onToggleTheme: () => void
   onCloseMenu: () => void
   onNavigate: (view: ViewKey) => void
   onReload: () => void
@@ -19,10 +21,12 @@ export function AppShell({
   children,
   isMenuOpen,
   activeView,
+  theme,
   viewer,
   viewerError,
   logoutURL,
   onToggleMenu,
+  onToggleTheme,
   onCloseMenu,
   onNavigate,
   onReload
@@ -49,6 +53,10 @@ export function AppShell({
         <div className="topbar-meta">
           <span className="view-chip">{viewLabel(activeView)}</span>
           <span className="user-chip">{viewer?.name || viewer?.id || "ゲスト"}</span>
+          <button type="button" className="theme-toggle" onClick={onToggleTheme} aria-label="テーマ切り替え">
+            <span className="theme-dot" />
+            {theme === "dark" ? "Dark" : "Light"}
+          </button>
         </div>
       </header>
 
@@ -80,6 +88,9 @@ export function AppShell({
         <div className="drawer-divider" />
         <div className="drawer-group">
           <p className="drawer-subtitle">アカウント</p>
+          <button type="button" className="drawer-item" onClick={onToggleTheme}>
+            テーマ: {theme === "dark" ? "ダーク" : "ライト"}
+          </button>
           {viewer ? (
             <div className="account-card">
               <strong>{viewer.name || viewer.id}</strong>

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react"
+
+type Theme = "light" | "dark"
+
+const STORAGE_KEY = "syukatsu-theme"
+
+function resolveInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light"
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored === "light" || stored === "dark") {
+    return stored
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => resolveInitialTheme())
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.toggle("dark", theme === "dark")
+    window.localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"))
+  }, [])
+
+  return { theme, setTheme, toggleTheme }
+}
+

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Zen Kaku Gothic New", "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Meiryo", "sans-serif"]
+      }
+    }
+  },
+  plugins: []
+}
+


### PR DESCRIPTION
## 概要
UI/UXのブラッシュアップとして、スタイル管理を Tailwind CSS ベースへ移行し、ライト/ダークのテーマ切替を追加しました。

## 変更内容
- Tailwind CSS / PostCSS / Autoprefixer を導入
- App.css を @layer + クラス中心の構成へ再編
- ルート要素の dark クラス切替でテーマを実装（useTheme 追加）
- ヘッダー/ドロワーからテーマ切替できるUIを追加
- フォームとボタンの見た目を整理し、誤操作しやすかった削除ボタンを utton-danger として強調
- ステップ追加エリアの余白・配置を調整し、操作しやすさを改善

## 確認
- Docker 上の Node 20 で 
pm ci && npm run build 成功
- TypeScript ビルドと Vite ビルドが通過

## 影響範囲
- フロントエンド（React + CSS）のみ
- API仕様・バックエンド処理の変更なし
